### PR TITLE
cmd/comments: use `XyzRoute()` pattern

### DIFF
--- a/pkg/comments/auth.go
+++ b/pkg/comments/auth.go
@@ -1,0 +1,27 @@
+package comments
+
+import (
+	pz "github.com/weberc2/httpeasy"
+	"github.com/weberc2/mono/pkg/auth/client"
+)
+
+type Auth struct {
+	client.AuthType
+	client.Authenticator
+}
+
+func (a *Auth) Auth(r pz.Route) pz.Route {
+	return pz.Route{
+		Method:  r.Method,
+		Path:    r.Path,
+		Handler: a.Authenticator.Auth(a.AuthType, r.Handler),
+	}
+}
+
+func (a *Auth) Optional(r pz.Route) pz.Route {
+	return pz.Route{
+		Method:  r.Method,
+		Path:    r.Path,
+		Handler: a.Authenticator.Optional(a.AuthType, r.Handler),
+	}
+}

--- a/pkg/comments/authcommentsservice.go
+++ b/pkg/comments/authcommentsservice.go
@@ -1,0 +1,32 @@
+package comments
+
+import (
+	pz "github.com/weberc2/httpeasy"
+)
+
+type AuthCommentsService struct {
+	CommentsService
+	Auth Auth
+}
+
+func (acs *AuthCommentsService) Routes() []pz.Route {
+	return []pz.Route{
+		acs.RepliesRoute(),
+		acs.PutRoute(),
+		acs.GetRoute(),
+		acs.DeleteRoute(),
+		acs.UpdateRoute(),
+	}
+}
+
+func (acs *AuthCommentsService) PutRoute() pz.Route {
+	return acs.Auth.Auth(acs.CommentsService.PutRoute())
+}
+
+func (acs *AuthCommentsService) DeleteRoute() pz.Route {
+	return acs.Auth.Auth(acs.CommentsService.DeleteRoute())
+}
+
+func (acs *AuthCommentsService) UpdateRoute() pz.Route {
+	return acs.Auth.Auth(acs.CommentsService.UpdateRoute())
+}

--- a/pkg/comments/authcommentsservice_test.go
+++ b/pkg/comments/authcommentsservice_test.go
@@ -1,0 +1,72 @@
+package comments
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	pz "github.com/weberc2/httpeasy"
+	"github.com/weberc2/mono/pkg/auth/client"
+	"github.com/weberc2/mono/pkg/comments/testsupport"
+)
+
+func TestAuthCommentsService(t *testing.T) {
+	for _, testCase := range []struct {
+		name         string
+		method       func(*AuthCommentsService) pz.Route
+		requiresAuth bool
+	}{
+		{
+			name:         "replies",
+			method:       (*AuthCommentsService).RepliesRoute,
+			requiresAuth: false,
+		},
+		{
+			name:         "get",
+			method:       (*AuthCommentsService).GetRoute,
+			requiresAuth: false,
+		},
+		{
+			name:         "put",
+			method:       (*AuthCommentsService).PutRoute,
+			requiresAuth: true,
+		},
+		{
+			name:         "delete",
+			method:       (*AuthCommentsService).DeleteRoute,
+			requiresAuth: true,
+		},
+		{
+			name:         "update",
+			method:       (*AuthCommentsService).UpdateRoute,
+			requiresAuth: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			rsp := testCase.method(&AuthCommentsService{
+				CommentsService: CommentsService{
+					Comments: CommentsModel{
+						CommentsStore: testsupport.CommentsStoreFake{},
+						TimeFunc:      func() time.Time { return now },
+					},
+					TimeFunc: func() time.Time { return now },
+				},
+				Auth: Auth{
+					AuthType: client.ConstantAuthType(client.ResultErr(
+						"ERR",
+						errors.New("ERR"),
+					)),
+				},
+			}).Handler(pz.Request{Headers: make(http.Header)})
+
+			if !testCase.requiresAuth && rsp.Status == 401 {
+				t.Fatalf("expected no auth, but got `401`")
+			}
+
+			if testCase.requiresAuth && rsp.Status != 401 {
+				t.Fatalf("auth required--wanted `401`; found `%d`", rsp.Status)
+			}
+		})
+	}
+}

--- a/pkg/comments/authwebserver.go
+++ b/pkg/comments/authwebserver.go
@@ -2,41 +2,39 @@ package comments
 
 import (
 	pz "github.com/weberc2/httpeasy"
-	"github.com/weberc2/mono/pkg/auth/client"
 )
 
 type AuthWebServer struct {
 	WebServer
-	client.AuthType
-	client.Authenticator
+	Auth Auth
 }
 
 func (aws *AuthWebServer) RepliesRoute() pz.Route {
-	return aws.optional(aws.WebServer.RepliesRoute())
+	return aws.Auth.Optional(aws.WebServer.RepliesRoute())
 }
 
 func (aws *AuthWebServer) DeleteConfirmRoute() pz.Route {
-	return aws.auth(aws.WebServer.DeleteConfirmRoute())
+	return aws.Auth.Auth(aws.WebServer.DeleteConfirmRoute())
 }
 
 func (aws *AuthWebServer) DeleteRoute() pz.Route {
-	return aws.auth(aws.WebServer.DeleteRoute())
+	return aws.Auth.Auth(aws.WebServer.DeleteRoute())
 }
 
 func (aws *AuthWebServer) ReplyFormRoute() pz.Route {
-	return aws.auth(aws.WebServer.ReplyFormRoute())
+	return aws.Auth.Auth(aws.WebServer.ReplyFormRoute())
 }
 
 func (aws *AuthWebServer) ReplyRoute() pz.Route {
-	return aws.auth(aws.WebServer.ReplyRoute())
+	return aws.Auth.Auth(aws.WebServer.ReplyRoute())
 }
 
 func (aws *AuthWebServer) EditFormRoute() pz.Route {
-	return aws.auth(aws.WebServer.EditFormRoute())
+	return aws.Auth.Auth(aws.WebServer.EditFormRoute())
 }
 
 func (aws *AuthWebServer) EditRoute() pz.Route {
-	return aws.auth(aws.WebServer.EditRoute())
+	return aws.Auth.Auth(aws.WebServer.EditRoute())
 }
 
 func (aws *AuthWebServer) Routes() []pz.Route {
@@ -48,21 +46,5 @@ func (aws *AuthWebServer) Routes() []pz.Route {
 		aws.ReplyRoute(),
 		aws.EditFormRoute(),
 		aws.EditRoute(),
-	}
-}
-
-func (aws *AuthWebServer) auth(r pz.Route) pz.Route {
-	return pz.Route{
-		Method:  r.Method,
-		Path:    r.Path,
-		Handler: aws.Authenticator.Auth(aws.AuthType, r.Handler),
-	}
-}
-
-func (aws *AuthWebServer) optional(r pz.Route) pz.Route {
-	return pz.Route{
-		Method:  r.Method,
-		Path:    r.Path,
-		Handler: aws.Authenticator.Optional(aws.AuthType, r.Handler),
 	}
 }

--- a/pkg/comments/authwebserver_test.go
+++ b/pkg/comments/authwebserver_test.go
@@ -52,26 +52,27 @@ func TestAuthWebServer(t *testing.T) {
 			optional: false,
 		},
 	} {
-		rsp := testCase.method(&AuthWebServer{
-			WebServer: WebServer{
-				Comments: CommentsModel{
-					CommentsStore: testsupport.CommentsStoreFake{},
+		t.Run(testCase.name, func(t *testing.T) {
+			rsp := testCase.method(&AuthWebServer{
+				WebServer: WebServer{
+					Comments: CommentsModel{
+						CommentsStore: testsupport.CommentsStoreFake{},
+					},
 				},
-			},
-			AuthType: client.ConstantAuthType(client.ResultErr(
-				"ERR",
-				errors.New("ERR"),
-			)),
-		}).Handler(pz.Request{Headers: make(http.Header)})
+				Auth: Auth{
+					AuthType: client.ConstantAuthType(client.ResultErr(
+						"ERR",
+						errors.New("ERR"),
+					)),
+				},
+			}).Handler(pz.Request{Headers: make(http.Header)})
 
-		if testCase.optional && rsp.Status == 401 {
-			t.Fatalf("expected optional authentication, but got `401`")
-		}
-		if !testCase.optional && rsp.Status != 401 {
-			t.Fatalf(
-				"expected required authentication--wanted `401`; found `%d`",
-				rsp.Status,
-			)
-		}
+			if testCase.optional && rsp.Status == 401 {
+				t.Fatal("expected optional authentication, but got `401`")
+			}
+			if !testCase.optional && rsp.Status != 401 {
+				t.Fatalf("auth required--wanted `401`; found `%d`", rsp.Status)
+			}
+		})
 	}
 }

--- a/pkg/comments/commentsservice.go
+++ b/pkg/comments/commentsservice.go
@@ -15,6 +15,14 @@ type CommentsService struct {
 	TimeFunc func() time.Time
 }
 
+func (cs *CommentsService) PutRoute() pz.Route {
+	return pz.Route{
+		Method:  "POST",
+		Path:    "/api/posts/{post-id}/comments",
+		Handler: cs.Put,
+	}
+}
+
 func (cs *CommentsService) Put(r pz.Request) pz.Response {
 	var c types.Comment
 	if err := r.JSON(&c); err != nil {
@@ -45,6 +53,14 @@ func (cs *CommentsService) Put(r pz.Request) pz.Response {
 	})
 }
 
+func (cs *CommentsService) RepliesRoute() pz.Route {
+	return pz.Route{
+		Method:  "GET",
+		Path:    "/api/posts/{post-id}/comments/{comment-id}/replies",
+		Handler: cs.Replies,
+	}
+}
+
 func (cs *CommentsService) Replies(r pz.Request) pz.Response {
 	var parent types.CommentID
 	if commentID := r.Vars["comment-id"]; commentID != "toplevel" {
@@ -60,6 +76,14 @@ func (cs *CommentsService) Replies(r pz.Request) pz.Response {
 	return pz.Ok(pz.JSON(comments))
 }
 
+func (cs *CommentsService) GetRoute() pz.Route {
+	return pz.Route{
+		Method:  "GET",
+		Path:    "/api/posts/{post-id}/comments/{comment-id}",
+		Handler: cs.Get,
+	}
+}
+
 func (cs *CommentsService) Get(r pz.Request) pz.Response {
 	comment, err := cs.Comments.Comment(
 		types.PostID(r.Vars["post-id"]),
@@ -69,6 +93,14 @@ func (cs *CommentsService) Get(r pz.Request) pz.Response {
 		return pz.HandleError("retrieving comment", err)
 	}
 	return pz.Ok(pz.JSON(comment))
+}
+
+func (cs *CommentsService) DeleteRoute() pz.Route {
+	return pz.Route{
+		Method:  "DELETE",
+		Path:    "/api/posts/{post-id}/comments/{comment-id}",
+		Handler: cs.Delete,
+	}
 }
 
 func (cs *CommentsService) Delete(r pz.Request) pz.Response {
@@ -147,6 +179,14 @@ func (wanted *DeleteCommentResponse) Compare(
 	}
 
 	return nil
+}
+
+func (cs *CommentsService) UpdateRoute() pz.Route {
+	return pz.Route{
+		Method:  "PATCH",
+		Path:    "/api/posts/{post-id}/comments/{comment-id}",
+		Handler: cs.Update,
+	}
 }
 
 func (cs *CommentsService) Update(r pz.Request) pz.Response {


### PR DESCRIPTION
pkg/comments: create new `Auth` type for use in `AuthWebServer` and `AuthCommentsService`
pkg/comments: add `XyzRoute()`s for `CommentsService`
pkg/comments: create `AuthCommentsService` type including `Routes()` method and tests
pkg/comments: factor `Auth` stuff out of `AuthWebServer` for reuse in `AuthCommentsService`
pkg/comments: fixed `TestAuthWebServer`
cmd/comments: use `AuthCommentsService.Routes()` instead of creating bespoke routes

Closes https://trello.com/c/NIha7woC/35-use-fooroute-pattern.