### PR TITLE
pkg/auth: login handler wasn't setting form action correctly on failure.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 )
 
 require (
+	github.com/PuerkitoBio/goquery v1.8.0 // indirect
+	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
+github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
+github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
+github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/aws/aws-sdk-go v1.42.25 h1:BbdvHAi+t9LRiaYUyd53noq9jcaAcfzOhSVbKfr6Avs=
 github.com/aws/aws-sdk-go v1.42.25/go.mod h1:gyRszuZ/icHmHAVE4gc/r+cfCmhA1AD+vqfWbgI+eHs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -44,6 +48,7 @@ github.com/weberc2/httpeasy v0.0.26 h1:BXfdW4nxEQlLB7v0GXJlAj67YcIlbB5WuBa1xYzPt
 github.com/weberc2/httpeasy v0.0.26/go.mod h1:vjZmTmHJEPKRm2tITDQyIneHOAJvyk3KhFox6MvT/2Y=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/auth/webserver.go
+++ b/pkg/auth/webserver.go
@@ -236,6 +236,22 @@ func (ws *WebServer) RegistrationConfirmationHandlerRoute() pz.Route {
 	}
 }
 
+func (ws *WebServer) PasswordResetFormRoute() pz.Route {
+	return routePasswordResetForm
+}
+
+func (ws *WebServer) PasswordResetHandlerRoute() pz.Route {
+	return routePasswordResetHandler(ws)
+}
+
+func (ws *WebServer) PasswordResetConfirmationFormRoute() pz.Route {
+	return routePasswordResetConfirmationForm
+}
+
+func (ws *WebServer) PasswordResetConfirmationHandlerRoute() pz.Route {
+	return routePasswordResetConfirmationHandler(ws)
+}
+
 func (ws *WebServer) LoginFormPage(r pz.Request) pz.Response {
 	query := r.URL.Query()
 
@@ -297,7 +313,9 @@ func (ws *WebServer) LoginHandler(r pz.Request) pz.Response {
 					FormAction   string
 					ErrorMessage string
 				}{
-					FormAction:   ws.BaseURL + "login",
+					// Not only do we need the correct path, but we also need
+					// to preserve the query params (e.g., `callback`).
+					FormAction:   r.URL.String(),
 					ErrorMessage: "Invalid credentials",
 				}),
 				&logging{
@@ -417,4 +435,8 @@ func parseForm(r pz.Request) (url.Values, error) {
 		return nil, fmt.Errorf("parsing form data: %w", err)
 	}
 	return form, nil
+}
+
+func mustHTML(t string) *html.Template {
+	return html.Must(html.New("").Parse(t))
 }

--- a/pkg/auth/webserver.go
+++ b/pkg/auth/webserver.go
@@ -236,22 +236,6 @@ func (ws *WebServer) RegistrationConfirmationHandlerRoute() pz.Route {
 	}
 }
 
-func (ws *WebServer) PasswordResetFormRoute() pz.Route {
-	return routePasswordResetForm
-}
-
-func (ws *WebServer) PasswordResetHandlerRoute() pz.Route {
-	return routePasswordResetHandler(ws)
-}
-
-func (ws *WebServer) PasswordResetConfirmationFormRoute() pz.Route {
-	return routePasswordResetConfirmationForm
-}
-
-func (ws *WebServer) PasswordResetConfirmationHandlerRoute() pz.Route {
-	return routePasswordResetConfirmationHandler(ws)
-}
-
 func (ws *WebServer) LoginFormPage(r pz.Request) pz.Response {
 	query := r.URL.Query()
 
@@ -435,8 +419,4 @@ func parseForm(r pz.Request) (url.Values, error) {
 		return nil, fmt.Errorf("parsing form data: %w", err)
 	}
 	return form, nil
-}
-
-func mustHTML(t string) *html.Template {
-	return html.Must(html.New("").Parse(t))
 }


### PR DESCRIPTION
When the login fails, the login handler should rewrite the form with an error message; however, it was dropping the query string part on the form action.

pkg/auth: fix the login handler's form action + tests

Fixes https://trello.com/c/RPfzJRqf/62-auth-successful-login-following-failed-login-redirects-to-login-form