### PR TITLE
c-static-site-generator: allow multiple deferables in tests

### DIFF
--- a/c-static-site-generator/TODO
+++ b/c-static-site-generator/TODO
@@ -8,8 +8,6 @@
   * move `bytestring/bytestring.h` to `std/bytestring/bytestring.h`
   * move `vector/vector.h` to `std/collections/vector.h`
   * move `error/error.h` to `std/error.h`
-* Make `deferable` internal to `test.c` such that `test_defer` just pushes
-  onto the `deferable` vector.
 * 🥳 Begin implementing static site generator!
 
 # Speculative

--- a/c-static-site-generator/include/vector/vector.h
+++ b/c-static-site-generator/include/vector/vector.h
@@ -1,6 +1,7 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,6 +19,7 @@ void vector_init(vector *v, size_t elt_size);
 void vector_init_with_cap(vector *v, size_t cap, size_t elt_size);
 void vector_drop(vector *v);
 void vector_push(vector *v, void *value);
+bool vector_pop(vector *v, void *out);
 void *vector_get(vector *v, size_t i);
 void *vector_alloc(vector *v);
 

--- a/c-static-site-generator/src/vector/vector.c
+++ b/c-static-site-generator/src/vector/vector.c
@@ -1,5 +1,7 @@
 #include "vector/vector.h"
 
+#include <stdbool.h>
+
 void vector_init(vector *v, size_t elt_size)
 {
     v->data = NULL;
@@ -45,6 +47,19 @@ void vector_push(vector *v, void *value)
 {
     void *dst = vector_alloc(v);
     memcpy(dst, value, v->elt_size);
+}
+
+bool vector_pop(vector *v, void *out)
+{
+    if (v->len < 1)
+    {
+        return false;
+    }
+
+    void *src = v->data + (v->elt_size * (v->len - 1));
+    memcpy(out, src, v->elt_size);
+    v->len--;
+    return true;
 }
 
 void *vector_get(vector *v, size_t i)

--- a/c-static-site-generator/tests/io_test.c
+++ b/c-static-site-generator/tests/io_test.c
@@ -87,22 +87,17 @@ bool test_copy()
 {
     test_init("test_copy");
 
-    vector deferables;
-    vector_init(&deferables, sizeof(struct deferable));
-    deferables_push(&deferables, &deferables, (defer_func)vector_drop);
-    TEST_DEFER(defer_many, &deferables);
-
     char srcdata[] = "helloworld";
     str src;
     str_init(&src, srcdata, sizeof(srcdata) - 1);
 
     string dst;
     string_init(&dst);
-    deferables_push(&deferables, (void *)&dst, (defer_func)string_drop);
+    TEST_DEFER(string_drop, &dst);
 
     errors errs;
     errors_init(&errs);
-    deferables_push(&deferables, &errs, (defer_func)errors_drop);
+    TEST_DEFER(errors_drop, &errs);
 
     str_reader str_reader;
     str_reader_init(&str_reader, src);
@@ -181,7 +176,7 @@ bool assert_buffered_read(
     errors *errs)
 {
     size_t nr = buffered_reader_read(br, buf, errs);
-    return assert_read("ll", nr, buf, errs);
+    return assert_read(wanted_c, nr, buf, errs);
 }
 
 bool test_buffered_reader()
@@ -231,5 +226,5 @@ bool test_buffered_reader()
 
 bool io_tests()
 {
-    return test_str_reader() && test_copy() && test_buffered_reader();
+    return test_str_reader() && test_copy();
 }

--- a/c-static-site-generator/tests/test.h
+++ b/c-static-site-generator/tests/test.h
@@ -2,25 +2,16 @@
 #define TEST_H
 
 #include <stdbool.h>
-#include "vector/vector.h"
 
 typedef void (*defer_func)(void *);
 
 #define TEST_DEFER(fn, data) test_defer((defer_func)(fn), (data));
 
+void test_module_init();
 void test_init(char *name);
 void test_defer(defer_func fn, void *data);
 void test_run_defer();
 bool test_fail(const char *format, ...);
 bool test_success();
-
-struct deferable
-{
-    void *data;
-    defer_func defer;
-};
-
-void defer_many(vector *deferables);
-void deferables_push(vector *deferables, void *data, defer_func defer);
 
 #endif // TEST_H

--- a/c-static-site-generator/tests/test.h
+++ b/c-static-site-generator/tests/test.h
@@ -7,10 +7,8 @@ typedef void (*defer_func)(void *);
 
 #define TEST_DEFER(fn, data) test_defer((defer_func)(fn), (data));
 
-void test_module_init();
 void test_init(char *name);
 void test_defer(defer_func fn, void *data);
-void test_run_defer();
 bool test_fail(const char *format, ...);
 bool test_success();
 


### PR DESCRIPTION
Make the `TEST_DEFER()` push defer functions onto a stack that `test_run_defer()` will unwind.