### PR TITLE
c-static-site-generator: fixed bug in buffered_reader_read

### DIFF
--- a/c-static-site-generator/src/core/io/buffered_reader.c
+++ b/c-static-site-generator/src/core/io/buffered_reader.c
@@ -37,7 +37,6 @@ size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
     // reload the internal buffer.
     while (n < buf.len)
     {
-        br->cursor = 0;
         size_t nr = reader_read(br->source, br->buffer, res);
 
         // NB: we are deliberately *NOT* handling errors at this point--we
@@ -50,6 +49,10 @@ size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
         {
             break;
         }
+
+        // if we didn't read anything because we reached eof, we don't want to
+        // reset the cursor back to the beginning of the buffer.
+        br->cursor = 0;
 
         // otherwise we read something; let's copy it to the unwritten portion
         // of the output buffer.

--- a/c-static-site-generator/tests/io_test.c
+++ b/c-static-site-generator/tests/io_test.c
@@ -165,9 +165,9 @@ bool assert_buffered_read(
     return assert_read(wanted_c, nr, buf, res);
 }
 
-bool test_buffered_reader()
+bool test_buffered_reader_read()
 {
-    test_init("test_buffered_reader");
+    test_init("test_buffered_reader_read");
 
     char srcalloc[] = "helloworld!";
     str src_str;
@@ -206,10 +206,18 @@ bool test_buffered_reader()
     ASSERT_BUFFERED_READ("!");
 #undef ASSERT_BUFFERED_READ
 
+    if (br.cursor != src_str.len % buf.len)
+    {
+        return test_fail(
+            "cursor: wanted `%zu`; found `%zu`",
+            src_str.len,
+            br.cursor);
+    }
+
     return test_success();
 }
 
 bool io_tests()
 {
-    return test_str_reader() && test_copy();
+    return test_str_reader() && test_copy() && test_buffered_reader_read();
 }


### PR DESCRIPTION
* buffered_reader_read would reset cursor after eof; fixed + tests
* also discovered test_buffered_reader_read was not actually being run 