### PR TITLE
c-static-site-generator: fix `buffered_reader_read()` in the partial-rewind case

### DIFF
--- a/c-static-site-generator/include/core/error/error.h
+++ b/c-static-site-generator/include/core/error/error.h
@@ -11,7 +11,7 @@ typedef struct
 
 void error_init(error *err, void *data, display_func display);
 void error_null(error *err);
-void error_display(error err, formatter f);
+bool error_display(error err, formatter f);
 void error_const(error *err, const char *message);
 
 #endif // ERROR_H

--- a/c-static-site-generator/include/core/io/buffered_reader.h
+++ b/c-static-site-generator/include/core/io/buffered_reader.h
@@ -4,6 +4,7 @@
 #include "core/str/str.h"
 #include "core/result/result.h"
 #include "reader.h"
+#include "writer.h"
 
 typedef struct
 {
@@ -14,5 +15,12 @@ typedef struct
 
 void buffered_reader_init(buffered_reader *br, reader source, str buf);
 size_t buffered_reader_read(buffered_reader *br, str buf, result *res);
+bool buffered_reader_find(
+    buffered_reader *src,
+    writer dst,
+    result *res,
+    str match);
+
+void buffered_reader_to_reader(buffered_reader *br, reader *r);
 
 #endif // BUFFERED_READER_H

--- a/c-static-site-generator/include/core/io/buffered_reader.h
+++ b/c-static-site-generator/include/core/io/buffered_reader.h
@@ -11,6 +11,7 @@ typedef struct
     reader source;
     str buffer;
     size_t cursor;
+    size_t read_end;
 } buffered_reader;
 
 void buffered_reader_init(buffered_reader *br, reader source, str buf);

--- a/c-static-site-generator/include/core/io/writer.h
+++ b/c-static-site-generator/include/core/io/writer.h
@@ -15,4 +15,7 @@ typedef struct
 void writer_init(writer *w, void *data, write_func write);
 size_t writer_write(writer w, str s, result *res);
 
+error ERR_SHORT_WRITE;
+error ERR_INVALID_WRITE;
+
 #endif // WRITER_H

--- a/c-static-site-generator/include/core/result/result.h
+++ b/c-static-site-generator/include/core/result/result.h
@@ -9,7 +9,14 @@ typedef struct
     error err;
 } result;
 
+void result_init(result *res);
 void result_ok(result *res);
 void result_err(result *res, error err);
+
+#define TRY(res)   \
+    if ((res)->ok) \
+    {              \
+        return;    \
+    }
 
 #endif // RESULT_H

--- a/c-static-site-generator/include/core/str/str.h
+++ b/c-static-site-generator/include/core/str/str.h
@@ -17,4 +17,17 @@ size_t str_copy_at(str dst, str src, size_t start);
 bool str_eq(str lhs, str rhs);
 size_t str_copy_to_c(char *dst, str src, size_t len);
 
+typedef struct
+{
+    bool found;
+    size_t index;
+} str_find_result;
+
+str_find_result str_find(str s, str search);
+
+#define STR_NEW(var, data)       \
+    char __src_##var[] = (data); \
+    str(var);                    \
+    str_init(&(var), __src_##var, sizeof(__src_##var) - 1);
+
 #endif // STR_H

--- a/c-static-site-generator/include/std/string/string.h
+++ b/c-static-site-generator/include/std/string/string.h
@@ -12,6 +12,8 @@ typedef struct
 } string;
 
 void string_init(string *s);
+void string_from_slice(string *s, str src);
+void string_from_raw(string *s, char *data, size_t len);
 void string_drop(string *s);
 void string_push_raw(string *s, char *data, size_t len);
 void string_push_slice(string *s, str src);

--- a/c-static-site-generator/src/core/error/error.c
+++ b/c-static-site-generator/src/core/error/error.c
@@ -13,9 +13,9 @@ void error_null(error *err)
     err->display = NULL;
 }
 
-void error_display(error err, formatter f)
+bool error_display(error err, formatter f)
 {
-    err.display(err.data, f);
+    return err.display(err.data, f);
 }
 
 bool error_const_display(const char *message, formatter f)

--- a/c-static-site-generator/src/core/io/buffered_reader.c
+++ b/c-static-site-generator/src/core/io/buffered_reader.c
@@ -7,15 +7,16 @@ void buffered_reader_init(buffered_reader *br, reader source, str buf)
     br->source = source;
     br->buffer = buf;
     br->cursor = 0;
+    br->read_end = 0;
 }
 
 size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
 {
     size_t n;
-    if (br->cursor > 0 && br->cursor < br->buffer.len)
+    if (br->cursor > 0 && br->cursor < br->read_end)
     {
         str remaining;
-        str_slice(br->buffer, &remaining, br->cursor, br->buffer.len);
+        str_slice(br->buffer, &remaining, br->cursor, br->read_end);
         n = str_copy(buf, remaining);
         br->cursor += n;
 
@@ -51,7 +52,11 @@ size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
         }
 
         // if we didn't read anything because we reached eof, we don't want to
-        // reset the cursor back to the beginning of the buffer.
+        // reset the `read_end` back to the beginning of the buffer.
+        br->read_end = nr;
+
+        // if we didn't read anything because we reached eof, we don't want to
+        // reset the `cursor` back to the beginning of the buffer.
         br->cursor = 0;
 
         // otherwise we read something; let's copy it to the unwritten portion

--- a/c-static-site-generator/src/core/io/buffered_reader.c
+++ b/c-static-site-generator/src/core/io/buffered_reader.c
@@ -73,3 +73,120 @@ size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
     }
     return n;
 }
+
+bool buffered_reader_find(
+    buffered_reader *src,
+    writer dst,
+    result *res,
+    str match)
+{
+    char buf_[256];
+    str buf;
+    str_init(&buf, buf_, sizeof(buf_));
+
+    size_t match_cursor = 0;
+    while (true)
+    {
+        size_t nr;
+    READ_MORE:
+
+        nr = buffered_reader_read(src, buf, res);
+
+        str read_slice;
+        str_slice(buf, &read_slice, 0, nr);
+
+        // if we read 0 bytes, it means we reached `eof` without finding a
+        // match.
+        if (nr == 0)
+        {
+            return false;
+        }
+
+        // loop over the buffer to try and find a match--it's possible that we
+        // began matching but couldn't complete the match because the buffer
+        // ran out before the match was completed--`match_cursor` holds the
+        // index into `match` where we left off during the last iteration.
+        for (size_t i = 0; i < read_slice.len; i++)
+        {
+            for (size_t j = 0; j + match_cursor < match.len; j++)
+            {
+                // check to see if the current character is out-of-bounds of
+                // the read_slice--if so, then update the match_cursor and jump
+                // to the outermost loop.
+                if (i + j >= read_slice.len)
+                {
+                    match_cursor += read_slice.len;
+                    goto READ_MORE;
+                }
+
+                // if we got here, we're still in bounds of the previously-read
+                // data--check to see if we are still matching; if not, reset
+                // the match_cursor and jump to the next iteration of the match
+                // loop.
+                if (read_slice.data[i + j] != match.data[j + match_cursor])
+                {
+                    match_cursor = 0;
+                    goto RESET;
+                }
+            }
+
+            // If we got here, we completed a match, so we'll finish copying,
+            // reverse the `buffered_reader` cursor to the end of the match,
+            // and return `true`.
+            size_t match_end = i + (match.len - match_cursor);
+            size_t rewind = read_slice.len - match_end;
+            src->cursor -= rewind;
+
+            // slice the buffer up to the start of the match
+            str slice;
+            str_slice(read_slice, &slice, 0, i);
+
+            // write the new slice to the writer
+            result write_res;
+            result_init(&write_res);
+            size_t nw = writer_write(dst, slice, &write_res);
+
+            // handle write errors
+            if (!write_res.ok)
+            {
+                *res = write_res;
+                return true;
+            }
+
+            // at this point, `res` may or may not be `ok` (it may be
+            // in an `err` state from the previous read operation), but
+            // in either case we will return with the number of bytes
+            // copied.
+            return true;
+
+        RESET:
+            continue;
+        }
+
+        // we've scanned the slice of the buffer containing data from the
+        // last read and we never found a match--copy that slice of the buffer
+        // to the writer and loop back around, refreshing the buffer.
+        result write_res;
+        result_init(&write_res);
+        size_t nw = writer_write(dst, read_slice, &write_res);
+
+        // if there was a problem writing, return the error.
+        if (!write_res.ok)
+        {
+            *res = write_res;
+            return false;
+        }
+
+        // if we didn't write as many bytes as we read, return an error.
+        if (nw != nr)
+        {
+            result_err(res, ERR_SHORT_WRITE);
+            return false;
+        }
+    }
+}
+
+void buffered_reader_to_reader(buffered_reader *br, reader *r)
+{
+    reader_init(r, (void *)br, (read_func)buffered_reader_read);
+}

--- a/c-static-site-generator/src/core/io/copy.c
+++ b/c-static-site-generator/src/core/io/copy.c
@@ -2,15 +2,12 @@
 #include "core/result/result.h"
 #include "core/str/str.h"
 
-const char *const ERR_SHORT_WRITE = "short write";
-const char *const ERR_INVALID_WRITE = "invalid write";
-
 size_t copy(writer dst, reader src, result *res)
 {
     char buffer[256];
     str buf;
     str_init(&buf, buffer, sizeof(buffer));
-    buf.len = sizeof(buffer) - 1;
+    buf.len = sizeof(buffer);
 
     size_t written;
     while (true)
@@ -30,8 +27,7 @@ size_t copy(writer dst, reader src, result *res)
                 nw = 0;
                 if (!res->ok)
                 {
-                    error_const(&err, ERR_INVALID_WRITE);
-                    result_err(res, err);
+                    result_err(res, ERR_INVALID_WRITE);
                 }
             }
             written += nw;
@@ -43,8 +39,7 @@ size_t copy(writer dst, reader src, result *res)
 
             if (nr != nw)
             {
-                error_const(&err, ERR_SHORT_WRITE);
-                result_err(res, err);
+                result_err(res, ERR_SHORT_WRITE);
                 break;
             }
             if (!res->ok)

--- a/c-static-site-generator/src/core/io/writer.c
+++ b/c-static-site-generator/src/core/io/writer.c
@@ -1,6 +1,12 @@
 #include "core/io/writer.h"
 #include "core/result/result.h"
 
+void __attribute__((constructor)) init()
+{
+    error_const(&ERR_SHORT_WRITE, "short write");
+    error_const(&ERR_INVALID_WRITE, "invalid write");
+}
+
 void writer_init(writer *w, void *data, write_func write)
 {
     w->data = data;

--- a/c-static-site-generator/src/core/result/result.c
+++ b/c-static-site-generator/src/core/result/result.c
@@ -1,6 +1,12 @@
 #include <stdbool.h>
 #include "core/result/result.h"
 
+void result_init(result *res)
+{
+    res->ok = false;
+    error_const(&res->err, "program error: result not initialized");
+}
+
 void result_ok(result *res)
 {
     res->ok = true;

--- a/c-static-site-generator/src/core/str/str.c
+++ b/c-static-site-generator/src/core/str/str.c
@@ -27,6 +27,15 @@ void str_slice(str s, str *out, size_t start, size_t end)
             s.len,
             end);
     }
+    else if (start > end)
+    {
+        panic(
+            "slicing str with len `%zu`: start index `%zu` exceeds end index "
+            "`%zu`",
+            s.len,
+            start,
+            end);
+    }
 
     out->data = s.data + start;
     out->len = end - start;
@@ -57,4 +66,29 @@ size_t str_copy_to_c(char *dst, str src, size_t len)
     memmove(dst, src.data, copied);
     dst[copied] = '\0';
     return copied;
+}
+
+str_find_result str_find(str s, str search)
+{
+    if (search.len > s.len)
+    {
+        return (str_find_result){false, 0};
+    }
+
+    for (size_t i = 0; i < s.len; i++)
+    {
+        for (size_t j = 0; j < search.len; j++)
+        {
+            if (s.data[i + j] != search.data[j])
+            {
+                goto OUTER;
+            }
+        }
+
+        return (str_find_result){true, i};
+    OUTER:
+        continue;
+    }
+
+    return (str_find_result){false, 0};
 }

--- a/c-static-site-generator/src/std/string/string.c
+++ b/c-static-site-generator/src/std/string/string.c
@@ -11,6 +11,18 @@ void string_init(string *s)
     s->cap = 0;
 }
 
+void string_from_slice(string *s, str src)
+{
+    string_init(s);
+    string_push_slice(s, src);
+}
+
+void string_from_raw(string *s, char *data, size_t len)
+{
+    string_init(s);
+    string_push_raw(s, data, len);
+}
+
 void string_drop(string *s)
 {
     free(s->data);

--- a/c-static-site-generator/tests/io_test.c
+++ b/c-static-site-generator/tests/io_test.c
@@ -217,7 +217,180 @@ bool test_buffered_reader_read()
     return test_success();
 }
 
+typedef struct
+{
+    string pre_match_data;
+    writer w;
+    str_reader src_str_reader;
+    buffered_reader br;
+    str match;
+    result res;
+} buffered_reader_find_test_case;
+
+void buffered_reader_find_test_case_init(
+    buffered_reader_find_test_case *tc,
+    char *source_data,
+    size_t source_data_size,
+    char *buf,
+    size_t buf_size,
+    char *match_data,
+    size_t match_data_size)
+{
+    string_init(&tc->pre_match_data);
+    string_writer(&tc->w, &tc->pre_match_data);
+
+    str src_str;
+    str_init(&src_str, source_data, source_data_size);
+    str_reader_init(&tc->src_str_reader, src_str);
+
+    reader r;
+    str_reader_to_reader(&tc->src_str_reader, &r);
+
+    str buf_str;
+    str_init(&buf_str, buf, buf_size);
+
+    buffered_reader_init(&tc->br, r, buf_str);
+
+    str_init(&tc->match, match_data, match_data_size);
+}
+
+void buffered_reader_find_test_case_drop(buffered_reader_find_test_case *tc)
+{
+    string_drop(&tc->pre_match_data);
+}
+
+bool buffered_reader_find_test_case_run(
+    buffered_reader_find_test_case *tc,
+    bool wanted_match,
+    char *wanted_pre_match_data,
+    size_t wanted_pre_match_data_size,
+    char *wanted_post_match_data,
+    size_t wanted_post_match_data_size,
+    bool wanted_err)
+{
+    bool match = buffered_reader_find(&tc->br, tc->w, &tc->res, tc->match);
+    if (match && !wanted_match)
+    {
+        return test_fail("unexpected match");
+    }
+    if (!match && wanted_match)
+    {
+        return test_fail("unexpected match failure");
+    }
+
+    str wanted_pre_match, pre_match;
+    str_init(
+        &wanted_pre_match,
+        wanted_pre_match_data,
+        wanted_pre_match_data_size);
+    string_borrow(&tc->pre_match_data, &pre_match);
+    if (!str_eq(wanted_pre_match, pre_match))
+    {
+        char wanted[256] = {0}, found[256] = {0};
+        str_copy_to_c(wanted, wanted_pre_match, sizeof(wanted));
+        str_copy_to_c(found, pre_match, sizeof(found));
+        return test_fail(
+            "pre-match data: wanted `%s` (len %zu); found `%s` (len %zu)",
+            wanted,
+            wanted_pre_match.len,
+            found,
+            pre_match.len);
+    }
+
+    // check post-match data
+    string s;
+    string_init(&s);
+    TEST_DEFER(string_drop, &s);
+    writer w;
+    string_writer(&w, &s);
+    reader r;
+    buffered_reader_to_reader(&tc->br, &r);
+    result copy_res;
+    result_init(&copy_res);
+    copy(w, r, &copy_res);
+    if (!copy_res.ok)
+    {
+        string display;
+        string_init(&display);
+        TEST_DEFER(string_drop, &display);
+        formatter f;
+        string_formatter(&f, &display);
+        error_display(copy_res.err, f);
+        char message[256] = {0};
+        string_copy_to_c(message, &display, sizeof(message));
+        return test_fail(
+            "unexpected error copying post-match result: %s",
+            message);
+    }
+
+    str wanted_post_match, post_match;
+    string_borrow(&s, &post_match);
+    str_init(
+        &wanted_post_match,
+        wanted_post_match_data,
+        wanted_post_match_data_size);
+    if (!str_eq(wanted_post_match, post_match))
+    {
+        char wanted[256] = {0}, found[256] = {0};
+        str_copy_to_c(wanted, wanted_post_match, sizeof(wanted));
+        str_copy_to_c(found, post_match, sizeof(found));
+        return test_fail(
+            "post-match data: wanted `%s` (len: %zu); found `%s` (len %zu)",
+            wanted,
+            wanted_post_match.len,
+            found,
+            post_match.len);
+    }
+
+    if (wanted_err && tc->res.ok)
+    {
+        return test_fail("expected error, found no error");
+    }
+
+    if (!wanted_err && !tc->res.ok)
+    {
+        char message[256] = {0};
+        string s;
+        string_init(&s);
+        formatter f;
+        string_formatter(&f, &s);
+        if (!error_display(tc->res.err, f))
+        {
+            return test_fail("unexpected error formatting error message");
+        }
+        string_copy_to_c(message, &s, sizeof(message));
+        return test_fail("unexpected err: %s", message);
+    }
+
+    return test_success();
+}
+
+bool test_buffered_reader_find()
+{
+    test_init("test_buffered_reader_find");
+    buffered_reader_find_test_case tc;
+    char src[] = "foo bar baz";
+    char buf[256] = {0};
+    char match[] = "bar";
+    buffered_reader_find_test_case_init(
+        &tc,
+        src, sizeof(src) - 1,
+        buf, sizeof(buf),
+        match, sizeof(match) - 1);
+    TEST_DEFER(buffered_reader_find_test_case_drop, &tc);
+
+    return buffered_reader_find_test_case_run(
+        &tc,
+        true,
+        "foo ", sizeof("foo ") - 1,
+        " baz", sizeof(" baz") - 1,
+        false);
+}
+
 bool io_tests()
 {
-    return test_str_reader() && test_copy() && test_buffered_reader_read();
+    return test_str_reader() &&
+           test_copy() &&
+           test_buffered_reader_read() &&
+           test_buffered_reader_find();
 }


### PR DESCRIPTION
* added `read_end` field to `buffered_reader` to track the end of a read (in cases where a read doesn't fill the inner buffer)
* copy up to `read_end` from the inner buffer to the output buffer (instead of copying the full input buffer)