### PR TITLE
c-static-site-generator: fix buffered_reader_read() for the partial rewind case

### DIFF
--- a/c-static-site-generator/include/core/io/buffered_reader.h
+++ b/c-static-site-generator/include/core/io/buffered_reader.h
@@ -10,6 +10,7 @@ typedef struct
     reader source;
     str buffer;
     size_t cursor;
+    size_t read_end;
 } buffered_reader;
 
 void buffered_reader_init(buffered_reader *br, reader source, str buf);

--- a/c-static-site-generator/include/core/result/result.h
+++ b/c-static-site-generator/include/core/result/result.h
@@ -9,6 +9,7 @@ typedef struct
     error err;
 } result;
 
+void result_init(result *res);
 void result_ok(result *res);
 void result_err(result *res, error err);
 

--- a/c-static-site-generator/src/core/io/buffered_reader.c
+++ b/c-static-site-generator/src/core/io/buffered_reader.c
@@ -7,15 +7,16 @@ void buffered_reader_init(buffered_reader *br, reader source, str buf)
     br->source = source;
     br->buffer = buf;
     br->cursor = 0;
+    br->read_end = 0;
 }
 
 size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
 {
     size_t n;
-    if (br->cursor > 0 && br->cursor < br->buffer.len)
+    if (br->cursor > 0 && br->cursor < br->read_end)
     {
         str remaining;
-        str_slice(br->buffer, &remaining, br->cursor, br->buffer.len);
+        str_slice(br->buffer, &remaining, br->cursor, br->read_end);
         n = str_copy(buf, remaining);
         br->cursor += n;
 
@@ -51,7 +52,11 @@ size_t buffered_reader_read(buffered_reader *br, str buf, result *res)
         }
 
         // if we didn't read anything because we reached eof, we don't want to
-        // reset the cursor back to the beginning of the buffer.
+        // reset the `read_end` back to the beginning of the buffer.
+        br->read_end = nr;
+
+        // if we didn't read anything because we reached eof, we don't want to
+        // reset the `cursor` back to the beginning of the buffer.
         br->cursor = 0;
 
         // otherwise we read something; let's copy it to the unwritten portion

--- a/c-static-site-generator/src/core/result/result.c
+++ b/c-static-site-generator/src/core/result/result.c
@@ -1,6 +1,12 @@
 #include <stdbool.h>
 #include "core/result/result.h"
 
+void result_init(result *res)
+{
+    res->ok = false;
+    error_const(&res->err, "program error: result not initialized");
+}
+
 void result_ok(result *res)
 {
     res->ok = true;

--- a/c-static-site-generator/tests/io_test.c
+++ b/c-static-site-generator/tests/io_test.c
@@ -217,7 +217,78 @@ bool test_buffered_reader_read()
     return test_success();
 }
 
+bool test_buffered_reader_read__partial_rewind()
+{
+    test_init("test_buffered_reader_read__partial_rewind");
+    char src_[] = "foo";
+    char innerbuf_[128] = {0};
+    char outerbuf_[256] = {0};
+
+    str src, innerbuf, outerbuf;
+    str_init(&src, src_, sizeof(src_) - 1);
+    str_init(&innerbuf, innerbuf_, sizeof(innerbuf_) - 1);
+    str_init(&outerbuf, outerbuf_, sizeof(outerbuf_) - 1);
+
+    str_reader src_str_reader;
+    reader r;
+    buffered_reader br;
+    str_reader_init(&src_str_reader, src);
+    str_reader_to_reader(&src_str_reader, &r);
+    buffered_reader_init(&br, r, innerbuf);
+
+    result res;
+    result_init(&res);
+    size_t nr = buffered_reader_read(&br, outerbuf, &res);
+    ASSERT_OK(res);
+
+    if (nr != sizeof(src_) - 1)
+    {
+        return test_fail(
+            "bytes read: wanted `%zu`; found `%zu`",
+            sizeof(src_) - 1,
+            nr);
+    }
+
+    str found;
+    str_slice(outerbuf, &found, 0, nr);
+    if (!str_eq(src, found))
+    {
+        char found_[256] = {0};
+        str_copy_to_c(found_, found, sizeof(found_));
+        return test_fail("wanted `%s`; found `%s`", src_, found_);
+    }
+
+    // try rewinding, but not all the way
+    size_t new_cursor = 1;
+    br.cursor = new_cursor;
+    nr = buffered_reader_read(&br, outerbuf, &res);
+    ASSERT_OK(res);
+
+    if (nr != sizeof(src_) - 1 - new_cursor)
+    {
+        return test_fail(
+            "bytes read: wanted `%zu`; found `%zu`",
+            sizeof(src_) - 1 - new_cursor,
+            nr);
+    }
+
+    str wanted;
+    str_slice(outerbuf, &found, 0, nr);
+    str_slice(src, &wanted, new_cursor, src.len);
+    if (!str_eq(wanted, found))
+    {
+        char found_[256] = {0};
+        str_copy_to_c(found_, found, sizeof(found_));
+        return test_fail("wanted `%s`; found `%s`", src_ + new_cursor, found_);
+    }
+
+    return test_success();
+}
+
 bool io_tests()
 {
-    return test_str_reader() && test_copy() && test_buffered_reader_read();
+    return test_str_reader() &&
+           test_copy() &&
+           test_buffered_reader_read() &&
+           test_buffered_reader_read__partial_rewind();
 }


### PR DESCRIPTION
* added `read_end` field to `buffered_reader` to track the end of a read (in cases where a read doesn't fill the inner buffer)
* copy up to `read_end` from the inner buffer to the output buffer (instead of copying the full input buffer)
* add new `result_init()` function to initialize results to a program-error value to make it more obvious if a function doesn't properly populate a result value