### PR TITLE
c-static-site-generator: use convenience function style for strings

### DIFF
--- a/c-static-site-generator/include/std/string/string.h
+++ b/c-static-site-generator/include/std/string/string.h
@@ -12,11 +12,12 @@ typedef struct
 } string;
 
 void string_init(string *s);
+string string_new();
 void string_drop(string *s);
 void string_push_raw(string *s, char *data, size_t len);
 void string_push_slice(string *s, str src);
-void string_borrow(string *s, str *out);
-void string_slice(string *s, str *out, size_t start, size_t len);
+str string_borrow(string *s);
+str string_slice(string *s, size_t start, size_t end);
 void string_copy_to_c(char *dst, string *s, size_t len);
 
 #endif // STRING_H

--- a/c-static-site-generator/src/std/string/string.c
+++ b/c-static-site-generator/src/std/string/string.c
@@ -1,3 +1,4 @@
+#include "core/str/str.h"
 #include "std/string/string.h"
 #include "core/math/math.h"
 
@@ -9,6 +10,13 @@ void string_init(string *s)
     s->data = NULL;
     s->len = 0;
     s->cap = 0;
+}
+
+string string_new()
+{
+    string s;
+    string_init(&s);
+    return s;
 }
 
 void string_drop(string *s)
@@ -43,16 +51,14 @@ void string_push_slice(string *s, str src)
     string_push_raw(s, src.data, src.len);
 }
 
-void string_borrow(string *s, str *out)
+str string_borrow(string *s)
 {
-    out->data = s->data;
-    out->len = s->len;
+    return str_new(s->data, s->len);
 }
 
-void string_slice(string *s, str *out, size_t start, size_t end)
+str string_slice(string *s, size_t start, size_t end)
 {
-    string_borrow(s, out);
-    *out = str_slice(*out, start, end);
+    return str_slice(string_borrow(s), start, end);
 }
 
 void string_copy_to_c(char *dst, string *s, size_t len)

--- a/c-static-site-generator/tests/buffered_reader_test.c
+++ b/c-static-site-generator/tests/buffered_reader_test.c
@@ -97,10 +97,9 @@ bool find_test_case_run(find_test_case *tc)
     buffered_reader_init(&br, r, inner_buf);
 
     // init writer
-    string s;
     writer w;
     result res;
-    string_init(&s);
+    string s = string_new();
     string_writer(&w, &s);
     result_init(&res);
 
@@ -135,8 +134,7 @@ bool find_test_case_run(find_test_case *tc)
             error_to_raw(res.err, m, sizeof(m)));
     }
 
-    str actual_prelude;
-    string_borrow(&s, &actual_prelude);
+    str actual_prelude = string_borrow(&s);
     if (!str_eq(wanted_prelude, actual_prelude))
     {
         char wanted[256] = {0}, actual[256] = {0};
@@ -146,13 +144,12 @@ bool find_test_case_run(find_test_case *tc)
         return test_fail("prelude: wanted `%s`; found `%s`", wanted, actual);
     }
 
-    string postlude;
     str actual_postlude;
-    string_init(&postlude);
+    string postlude = string_new();
     string_writer(&w, &postlude);
     buffered_reader_to_reader(&br, &r);
     copy(w, r, &res);
-    string_borrow(&postlude, &actual_postlude);
+    str actual_postlude = string_borrow(&postlude);
     ASSERT_OK(res);
     if (!str_eq(wanted_postlude, actual_postlude))
     {

--- a/c-static-site-generator/tests/buffered_reader_test.c
+++ b/c-static-site-generator/tests/buffered_reader_test.c
@@ -144,7 +144,6 @@ bool find_test_case_run(find_test_case *tc)
         return test_fail("prelude: wanted `%s`; found `%s`", wanted, actual);
     }
 
-    str actual_postlude;
     string postlude = string_new();
     string_writer(&w, &postlude);
     buffered_reader_to_reader(&br, &r);

--- a/c-static-site-generator/tests/io_test.c
+++ b/c-static-site-generator/tests/io_test.c
@@ -84,8 +84,7 @@ bool test_copy()
     char srcdata[] = "helloworld";
     str src = str_new(srcdata, sizeof(srcdata) - 1);
 
-    string dst;
-    string_init(&dst);
+    string dst = string_new();
     TEST_DEFER(string_drop, &dst);
 
     result res;
@@ -109,9 +108,7 @@ bool test_copy()
             nc);
     }
 
-    str dstslice;
-    string_borrow(&dst, &dstslice);
-    if (!str_eq(src, dstslice))
+    if (!str_eq(src, string_borrow(&dst)))
     {
         return test_fail("wanted `%s`; found `%s`", src.data, dst.data);
     }

--- a/c-static-site-generator/tests/test.c
+++ b/c-static-site-generator/tests/test.c
@@ -67,8 +67,7 @@ bool test_success()
 
 char *error_to_raw(error err, char *buf, size_t size)
 {
-    string s;
-    string_init(&s);
+    string s = string_new();
     formatter f;
     string_formatter(&f, &s);
 


### PR DESCRIPTION
* create string_new() method
* replace string_init() calls with string_new()
* string_slice() now returns a str instead of taking an out param
* string_borrow() now returns a str instead of taking an out param